### PR TITLE
Fix moving to working directory

### DIFF
--- a/sane/action_launcher.py
+++ b/sane/action_launcher.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
 import sys
 import os
-import pickle
-import logging
+
 
 if __name__ == "__main__":
   filepath = os.path.dirname( os.path.abspath( __file__ ) )
   package_path = os.path.abspath( os.path.join( filepath, ".." ) )
   if package_path not in sys.path:
-      sys.path.append( package_path )
+    sys.path.append( package_path )
 
   import sane
 
   working_directory = sys.argv[1]
   action_file       = sys.argv[2]
 
-  os.chdir( working_directory )
-
   action = sane.save_state.load( action_file )
   action.override_logname( f"{action.id}::launch" )
   action.log(  "*" * 15 + "{:^15}".format( "Inside action_launcher.py" ) + "*" * 15 )
+  cwd = os.getcwd()
+  action.log( f"Current directory: {cwd}")
+  if cwd != working_directory:
+    action.log( f"Changing directory to: {working_directory}")
+    os.chdir( working_directory )
+
   action.log( f"Loaded Action \"{action.id}\"" )
 
   if "file" not in action.host_info:

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -10,7 +10,7 @@ import sane.host
 
 
 class HPCHost( sane.Host ):
-  HPC_DELAY_PERIOD_SECONDS = 60
+  HPC_DELAY_PERIOD_SECONDS = 30
 
   def __init__( self, name, aliases=[] ):
     super().__init__( name=name, aliases=aliases )

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -88,7 +88,7 @@ class HPCHost( sane.Host ):
   def post_launch( self, action, retval, content ):
     if not self._launch_local( action ):
       if retval != 0:
-        msg = f"Submission of Action {action.id} failed. Will not have job id"
+        msg = f"Submission of Action '{action.id}' failed. Will not have job id"
         self.log( msg, level=40 )
         raise Exception( msg )
       self._job_ids[action.id] = self.extract_job_id( content )

--- a/sane/logger.py
+++ b/sane/logger.py
@@ -38,8 +38,11 @@ class Logger:
   def restore_logname( self ):
     if len( self._logname_stack ) > 0:
       self._logname_stack.pop()
-    name = self._logname if len( self._logname_stack ) == 0 else self._logname_stack[-1]
-    self._set_label( name )
+    self._set_label( self.last_logname )
+
+  @property
+  def last_logname( self ):
+    return self._logname if len( self._logname_stack ) == 0 else self._logname_stack[-1]
 
   def _set_label( self, name ):
     self._label             = "{0:<{1}}".format( "[{0}] ".format( name ), LABEL_LENGTH + 3 )

--- a/sane/orchestrator.py
+++ b/sane/orchestrator.py
@@ -109,6 +109,7 @@ class Orchestrator( jconfig.JSONConfig ):
   @working_directory.setter
   def working_directory( self, path ):
     self._working_directory = path
+    os.chdir( self._working_directory )
 
   @property
   def save_location( self ):

--- a/sane/orchestrator.py
+++ b/sane/orchestrator.py
@@ -457,7 +457,7 @@ class Orchestrator( jconfig.JSONConfig ):
           processed_nodes.remove( node )
         elif not run_state:
           # If we get here, we DO want to error
-          msg = f"Action {node} did not return finished state : {self.actions[node].state.value}"
+          msg = f"Action '{node}' did not return finished state : {self.actions[node].state.value}"
           self.log( msg, level=50 )
           raise Exception( msg )
 


### PR DESCRIPTION
When operating on an HPC compute node, the working directory is not always the same between systems. Thus, a working directory is passed to the `action_launcher.py` script. We must move to this working directory before performing any workflow setup as certain things, such as temp environment variable files, will not work as expected.

Minor fixes to logging and HPC sync time 