### PR TITLE
Track job completion within a class member

### DIFF
--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -24,6 +24,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
     self.job_suffix = ""
 
     self._job_ids = {}
+    self._completed = {}
 
     # These must be filled out by derived classes
     self._state_cmd = None
@@ -90,12 +91,11 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
     return self.capture_job_complete
 
   def capture_job_complete( self, actions, only_watchdog=True ):
-    completed = {}
-    while not self.kill_watchdog and ( only_watchdog or len( completed ) != len( self._job_ids ) ):
+    while not self.kill_watchdog and ( only_watchdog or ( len( self._completed ) != len( self._job_ids ) ) ):
       time.sleep( HPCHost.HPC_DELAY_PERIOD_SECONDS )
       for action_name, job_id in self._job_ids.items():
-        if action_name not in completed and ( self.dry_run or self.job_complete( job_id ) ):
-          completed[action_name] = job_id
+        if action_name not in self._completed and ( self.dry_run or self.job_complete( job_id ) ):
+          self._completed[action_name] = job_id
           status = self.dry_run or self.job_status( job_id )
           disclaimer = ""
           if self.dry_run:


### PR DESCRIPTION
Tracking job completion only within the `capture_job_complete` function causes a reevaluation of all jobs to check for completion. While this is normally fine assuming the implementation provided can check multiple times for a completed job, this causes the `on_job_complete` function to be called multiple times when the respective action has completed during the workflow run whilst the host watchdog is active, and then again when the `post_run_actions` synchronizes by waiting for all tracked actions.

The `on_job_complete` should be treated as a one-time function. In the case of the `PBSHost` it should do the true release of the resource requisition that was being held. The release could be checked to see if the respective named requisition exists, but ideally if it does not this _should_ be treated as an error since it can only be released once. This further reinforces the concept that `on_job_complete` should be called only once per tracked job.