### PR TITLE
Autoqueue with priority

### DIFF
--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -3,6 +3,7 @@ import re
 import math
 import time
 import subprocess
+from functools import reduce
 
 import sane.action
 import sane.resources
@@ -190,13 +191,20 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
     account = specific_resources.get( "account", self.account )
     timelimit = specific_resources.get( "timelimit", None )
 
+    submit_args, submit_queue = self.submit_args( specific_resources, action.logname )
+
+    if queue is not None and submit_queue is not None:
+      self.log( f"Host or Action provided queue '{queue}' does not match resource queue '{submit_queue}'", level=40 )
+      raise RuntimeError( "Mismatched queue" )
+
+    queue = queue or submit_queue
+
     if queue is None or account is None:
       missing = "queue" if queue is None else "account"
       msg = f"No {missing} provided for Host {self.name} or Action {action.id} in HPC submission resources"
       self.log( msg, level=40 )
       raise KeyError( msg )
 
-    submit_args = self.submit_args( specific_resources, action.logname )
     default_submit = {
                               "name"       : f"sane.workflow.{action.id}{self.job_suffix}",
                               "output"     : action.logfile,
@@ -415,13 +423,28 @@ class PBSHost( HPCHost ):
         resource_dicts.append( select_dict )
 
     requisition = {}
+    queue       = resource_dict.get( "queue", None )
     resolved = True
-    for res_dict in resource_dicts:
-      # These are the resources we *can* provide
-      available_resources = set()
-      for homogeneous_nodes, node_resources in self._resources.items():
-        available_resources = available_resources | set( node_resources["node"].resources.keys() )
 
+    # These are the resources we *can* provide by queue
+    available_resources_by_queue = {}
+    available_resources = set()
+    for homogeneous_nodes, node_resources in self._resources.items():
+      for q in node_resources["queues"]:
+        # Init the set if not already tracked
+        if q not in available_resources_by_queue:
+          available_resources_by_queue[q] = set()
+
+        # Add to that queue what we can possibly offer
+        available_resources_by_queue[q] = available_resources_by_queue[q] | set( node_resources["node"].resources.keys() )
+        available_resources = available_resources | available_resources_by_queue[q]
+
+
+    # Sanitize resource dict into specifics and find the numeric resources we will
+    # concern ourselves with fulfilling
+    specified_resource_dicts = []
+    numeric_resources_per_dict = []
+    for res_dict in resource_dicts:
       specified_resource_dict = res_dict.copy()
       # Map to specific name-mapped resources, converting generics to specifics
       # Use list to get the instantaneous resources
@@ -440,10 +463,37 @@ class PBSHost( HPCHost ):
           specified_resource_dict[resource] = sane.resources.Resource( resource, specified_resource_dict[resource] ).total
           numeric_resources.append( resource )
 
+      specified_resource_dicts.append( specified_resource_dict )
+      numeric_resources_per_dict.append( numeric_resources )
+
+    # Find which queue and which nodesets to use
+    if queue is None:
+      all_resources = set()
+      for nr in numeric_resources_per_dict:
+        all_resources = all_resources | set( nr )
+
+      for q, available_resources in available_resources_by_queue.items():
+        if all_resources <= available_resources:
+          queue = q
+          break
+    else:
+      # make sure queue selected will suffice, nominally speaking
+      if queue not in available_resources_by_queue:
+        msg = f"Requested queue '{queue}' does not exist"
+        self.log( msg, level=50 )
+        raise RuntimeError( msg )
+      elif not all_resources <= available_resources_by_queue[queue]:
+        msg = f"Requested queue '{queue}' cannot provide all required resources"
+        self.log( msg, 50 )
+        raise RuntimeError( msg )
+      # else: # queue is fine to try to provide all resources
+
+    self.log( f"Creating resource requisition from queue '{queue}'", level=15 )
+    for specified_resource_dict, numeric_resources in zip( specified_resource_dicts, numeric_resources_per_dict ):
       self.log( f"Finding resources for '{requestor.logname}' : {specified_resource_dict}", level=15 )
 
       # These are the resources that should be provided by the end of this
-      required_resources = available_resources & set( numeric_resources )
+      required_resources = available_resources_by_queue[queue] & set( numeric_resources )
 
       resources_satisfied = {}
       node_pool_visited = {}
@@ -452,6 +502,9 @@ class PBSHost( HPCHost ):
         nodeset_name  = None
 
         for homogeneous_nodes, node_resources in self._resources.items():
+          # Skip nodes not in our queue
+          if queue not in node_resources["queues"]:
+            continue
           # Skip nodes that already provided resources and thus cannot provide more
           if homogeneous_nodes in node_pool_visited:
             continue
@@ -556,6 +609,7 @@ class PBSHost( HPCHost ):
 
   def requisition_to_submit_args( self, requisition ):
     host_arguments = []
+    queues = []
     for nodeset, req in requisition.items():
       submit_args = []
       if len( host_arguments ) == 0:
@@ -574,7 +628,12 @@ class PBSHost( HPCHost ):
       else:
         host_arguments[0][1].extend( submit_args )
 
-    return host_arguments
+      queues.append( self._resources[nodeset]["queues"] )
+
+    # Find the common queue
+    queue = list( reduce( set.intersection, map( set, queues ) ) )[0]
+
+    return host_arguments, queue
 
   def remove_hpc_kw( self, resource_dict ):
     res_dict = resource_dict.copy()

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -609,7 +609,7 @@ class PBSHost( HPCHost ):
 
   def requisition_to_submit_args( self, requisition ):
     host_arguments = []
-    queues = []
+    queues = [[None]]   # Default to [None] if no requisition exists
     for nodeset, req in requisition.items():
       submit_args = []
       if len( host_arguments ) == 0:

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -522,7 +522,7 @@ class PBSHost( HPCHost ):
           # else
           # do not error out as this may be provided by another homogeneous select
 
-        amounts["nodes"] = nodes
+        amounts["nodes"] = nodes if self._resources[nodeset_name]["exclusive"] else 0
         requisition[nodeset_name] = { "amounts" : amounts, "select_amounts" : select_amounts, "nodes" : nodes }
 
         # This is a duplication of the logic above, but just a whole check

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -320,16 +320,18 @@ class PBSHost( HPCHost ):
       else:
         nodes = int( hardware_info["nodes"] )
         exclusive = hardware_info.get( "exclusive", False )
+        queues = hardware_info.get( "queues", [None] )
         node_resource_dict = hardware_info["resources"]
-        self.add_resources( node_type, node_resource_dict, nodes, exclusive )
+        self.add_resources( node_type, node_resource_dict, nodes, exclusive, queues )
 
-  def add_resources( self, node_type, node_resource_dict, nodes, exclusive=False ):
+  def add_resources( self, node_type, node_resource_dict, nodes, exclusive=False, queues=[None] ):
     if node_type in self._resources:
       self.log( f"Node type '{node_type}' already exists" )
     else:
       self.log( f"Adding homogeneous node resources for '{node_type}'" )
       self._resources[node_type] = {
                                       "exclusive" : exclusive,
+                                      "queues"    : queues,
                                       "node" : sane.resources.ResourceProvider( mapper=self._mapper, logname=f"{self.name}::{node_type}" ),
                                       "total" : sane.resources.ResourceProvider( mapper=self._mapper, logname=f"{self.name}::{node_type}" )
                                     }

--- a/sane/orchestrator.py
+++ b/sane/orchestrator.py
@@ -10,6 +10,7 @@ import threading
 import re
 import datetime
 from concurrent.futures import ThreadPoolExecutor
+from collections import OrderedDict
 import xml.etree.ElementTree as xmltree
 import xml.dom.minidom
 
@@ -812,7 +813,7 @@ class Orchestrator( opts.OptionLoader ):
         continue
 
       with open( file, "r" ) as fp:
-        options = json.load( fp, cls=JSONCDecoder )
+        options = json.load( fp, cls=JSONCDecoder, object_pairs_hook=OrderedDict )
         self.log_push()
         self.load_options( options, file )
         self.log_pop()
@@ -924,7 +925,7 @@ class Orchestrator( opts.OptionLoader ):
 
     try:
       with open( self.save_file, "r" ) as f:
-        save_dict = json.load( f, cls=JSONCDecoder )
+        save_dict = json.load( f, cls=JSONCDecoder, object_pairs_hook=OrderedDict )
     except Exception as e:
       self.log( f"Could not open {self.save_file}", level=50 )
       raise e

--- a/tests/test_hpc_host.py
+++ b/tests/test_hpc_host.py
@@ -60,18 +60,22 @@ class HPCHostTests( unittest.TestCase ):
     dummy = sane.Action( "dummy" )
     self.test_pbs_host_from_options()
     _, submit_selection = self.host.pbs_resource_requisition( { "nodes" : 4, "cpus" : 256 }, dummy )
-    result = self.host._format_arguments( self.host.requisition_to_submit_args( submit_selection ) )
+    submit_args, submit_queue = self.host.requisition_to_submit_args( submit_selection )
+    result = self.host._format_arguments( submit_args )
     print( submit_selection )
     print( "Result: " + result )
     self.assertEqual( result, "-l select=4:ncpus=64" )
+    self.assertEqual( submit_queue, None )
 
 
     _, submit_selection = self.host.pbs_resource_requisition( { "nodes" : 4, "cpus" : 256, "select" : "select=1:ncpus=8:ngpus=1" }, dummy )
-    result = self.host._format_arguments( self.host.requisition_to_submit_args( submit_selection ) )
+    submit_args, submit_queue = self.host.requisition_to_submit_args( submit_selection )
+    result = self.host._format_arguments( submit_args )
     print( submit_selection )
     print( "Result: " + result )
     # Note that the ngpus:a100 must be fixed somehow down the line
     self.assertEqual( result, "-l select=1:ncpus=8:ngpus:a100=1" )
+    self.assertEqual( submit_queue, None )
 
 
   def test_pbs_host_resource_gen_wrapper( self ):
@@ -96,6 +100,7 @@ class HPCHostTests( unittest.TestCase ):
     orch.add_action( action )
     orch.dry_run = True
 
+    # Test that a queue and account must be provided in some manner
     with self.assertRaises( KeyError ):
       orch.run_actions( ["my_action"], as_host="test" )
     action.add_resource_requirements( { "test" : { "queue" : "queue_foo", "account" : "account_foo" } } )


### PR DESCRIPTION
Previously, queue info could only come from the action resource dict or the host settings, giving priority to the action's queue. These changes continue to support this priority but now allow requisitions to provide their own queue information. This queue is provided as an intermediate priority such that an action-provided queue is always prioritized.

Effectively, this allows actions that do not have queues designated on a multi-queue host providing multiple resource pools where the host also does not provide a queue to be auto-assigned a queue based on which queue services the resource pool of the requisition. This would reduce the need for actions or a host to precribe queues, and allow for more generalized and flexible workflow definitions.

The `submit_args` function now provides the args to be formatted as well as any potential queue info. The default assignment of `queues` for resource definitions is `[None]`, and should be assumed that `queue` at any point until `launch_wrapper` assigns the value can be `None`.

In the `PBSHost` during requisition determination, the `queue` is first set by the action resource `queue`, respecting the priority. If none exists, then the first `queue` that satisfies all numeric resources of the action's request is selected (which could be value `None`). The rest of the logic for determining which nodeset remains the same except that an additional check is added to make sure the nodeset is serviced (part of) by the selected queue. Because the default `queues` is `[None]`, when no action or best-fit `queue` is used because no queues are defined, the previous logic of considering all nodesets is applied.

Furthermore, this implies that that if nodesets do not define `queues` but actions do request a specific queue then the requisition will fail to be resolved since no nodesets service that `queue`. This is intended behavior as queues should be used to route to specific resources and if that specific resource route cannot be honored then a failure should occur.

When an action does provide a `queue` that is fulfilled by nodesets in that `queue`, the requisition `queue` should match the action `queue`. If they do not, an error is thrown. This is also possible if a nodeset services multiple queues and the wrong one is selected. This may be fixed in the future.

Resource pools / nodesets are priority checked based on instantiation order (order of appearance for JSON files).