### PR TITLE
Fix sane_view single plot

### DIFF
--- a/bin/sane_view.py
+++ b/bin/sane_view.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import sys
+from collections.abc import Iterable
 
 import json
 import math
@@ -130,7 +131,9 @@ def plot_usage( workflow_save, arrow_deltas, stem_timeline ):
     fig = plt.figure()
     fig.suptitle( times[view_time], fontsize="x-large" )
     subfigs = fig.subfigures( nx, ny )
-    if not isinstance( subfigs, list ):
+
+    if not isinstance( subfigs, Iterable ):
+      print( "Adjusting subfigures into a list..." )
       subfigs = [subfigs]
 
     for i, resource in enumerate( plots ):


### PR DESCRIPTION
When a single subfigure is created within matplotlib it returns only one Axes element. When more than one subfigure is generated, an iterable is returned. This was assumed to be a `list`, but is in fact an `ndarray` of Axes. Conversion to some sort of `Iterable` is necessary to make the remaining code functionally identical regardless of number of subplots.

The fix is to check if the returned value is `Iterable` rather than just `list`. As none of the subsequent code relies on it being an `ndarray` and there is no previous reference to `numpy` in this utility, conversion to a simple `list` is acceptable. 