### PR TITLE
Add command line option to patch

### DIFF
--- a/bin/sane_runner.py
+++ b/bin/sane_runner.py
@@ -118,6 +118,12 @@ def get_parser():
                       default=None,
                       help="Start a new workflow run and clear previous cache"
                       )
+  parser.add_argument(
+                      "--patch",
+                      type=str,
+                      default="",
+                      help="Apply a command-line patch at the very end of workflow loading, assume lowest priority"
+                      )
   virtual_group = parser.add_argument_group(
                                             "Virtual Launch (in situ aggregation)",
                                             "Creates temporary action to facilitate adaptive running of workflow"
@@ -185,6 +191,10 @@ def main():
   orchestrator.add_search_paths( options.path )
   orchestrator.add_search_patterns( options.search_pattern )
   orchestrator.load_paths()
+
+  # Apply command-line patch last
+  if options.patch:
+    orchestrator.process_patch_dict( "cli", json.loads( options.patch ) )
 
   action_list = options.actions.copy()
 

--- a/docs/source/reference/api/orch.rst
+++ b/docs/source/reference/api/orch.rst
@@ -63,6 +63,7 @@ Orchestrator
 
       .. automethod:: process_registered
       .. automethod:: process_patches
+      .. automethod:: process_patch_dict
       .. automethod:: find_host
       .. automethod:: construct_dag
       .. automethod:: traversal_list

--- a/sane/orchestrator.py
+++ b/sane/orchestrator.py
@@ -338,10 +338,29 @@ class Orchestrator( opts.OptionLoader ):
   def process_patches( self ) -> None:
     """Process JSON patches in priority order
 
-    All patches are processed in descending priority order (highest priority first),
-    with equal priority left in an undefined order. Following the processing order
-    of :py:meth:`load_core_options()`, any patch for :py:class:`sane.Host` is processed
-    first, then :py:class:`sane.Action`.
+    Process the stored JSON patches read in from :py:meth:`load_config_files` after
+    both JSON and python workflow files have been processed. First, they are sorted
+    in priority order, highest value first. Then for each patch `dict`
+    :py:meth:`process_patch_dict` is called using the path of the JSON file this
+    patch came from as the `origin`
+    """
+    # Higher number equals higher priority
+    # this makes default registered generally go last
+    keys = sorted( self._patch_options.keys(), reverse=True )
+    for key in keys:
+      for origin, patch in self._patch_options[key].items():
+        self.process_patch_dict( origin, patch )
+
+  def process_patch_dict( self, origin : str, patch : dict ) -> None:
+    """Process an individual patch dict without priority
+
+    Find the corresponding object(s) that already exist within the :py:class:`Orchestrator`
+    and call the respective :py:meth:`load_options` of an object with the sub-`dict`
+    as the value. The `patch` input argument should closely resemble the `options`
+    argument in :py:meth:`load_core_options`, with some minor caveats.
+    
+    Following the processing order of :py:meth:`load_core_options()`, any patch
+    for :py:class:`sane.Host` is processed first, then :py:class:`sane.Action`.
 
     Patches are applied, for a respective attribute (:py:attr:`hosts` or :py:attr:`actions`),
     either by finding a matching key in the attribute or if a patch filter for all matching keys.
@@ -371,46 +390,46 @@ class Orchestrator( opts.OptionLoader ):
     ``[action_00[0-5]]`` is a patch filter with ``action_00[0-5]`` as the match regex.
 
     Regardless of the patch applied or not, the effects are logged.
+
+    :param origin: Where this patch originates from, file or source code.
+    :param patch:  A `dict` similiar to :py:meth:`load_core_options`, containing
+                   a collection of `dicts` corresponding to a patched object's
+                   :py:meth:`load_options`
     """
-    # Higher number equals higher priority
-    # this makes default registered generally go last
     self.push_logscope( "patch" )
-    keys = sorted( self._patch_options.keys(), reverse=True )
-    for key in keys:
-      for origin, patch in self._patch_options[key].items():
-        self.log( f"Processing patches from {origin}" )
-        self.log_push()
-        # go through patches in priority order then apply hosts then actions, respectively
-        for pop_key, gentype, source in ( ( "hosts", "Host", self.hosts ), ( "actions", "Action", self.actions ) ):
-          patch_dicts = patch.pop( pop_key, {} )
-          for id, options in patch_dicts.items():
-            if id in source:
-              self.log( f"Applying patch to {gentype} '{id}'" )
-              source[id].log_push( 2 )
-              source[id].push_logscope( "patch" )
-              source[id].load_options( options.copy(), origin )
-              source[id].pop_logscope()
-              source[id].log_pop( 2 )
-            elif id.startswith( "[" ) and id.endswith( "]" ):
-              filter_ids = list( filter( lambda source_id: re.search( id[1:-1], source_id ), source.keys() ) )
-              if len( filter_ids ) > 0:
-                self.log( f"Applying patch filter '{id[1:-1]}' to [{len(filter_ids)}] {gentype}s" )
-                for filter_id in filter_ids:
-                  self.log( f"Applying patch filter to {gentype} '{filter_id}'", level=15 )
-                  source[filter_id].log_push( 2 )
-                  source[filter_id].push_logscope( "patch" )
-                  source[filter_id].load_options( options.copy(), origin )
-                  source[filter_id].pop_logscope()
-                  source[filter_id].log_pop( 2 )
-              else:
-                self.log( f"No {gentype} matches patch filter '{id[1:-1]}', cannot apply patch", level=30 )
-            else:
-              self.log( f"{gentype} '{id}' does not exist, cannot patch", level=30 )
+    self.log( f"Processing patches from {origin}" )
+    self.log_push()
+    # go through patches in priority order then apply hosts then actions, respectively
+    for pop_key, gentype, source in ( ( "hosts", "Host", self.hosts ), ( "actions", "Action", self.actions ) ):
+      patch_dicts = patch.pop( pop_key, {} )
+      for id, options in patch_dicts.items():
+        if id in source:
+          self.log( f"Applying patch to {gentype} '{id}'" )
+          source[id].log_push( 2 )
+          source[id].push_logscope( "patch" )
+          source[id].load_options( options.copy(), origin )
+          source[id].pop_logscope()
+          source[id].log_pop( 2 )
+        elif id.startswith( "[" ) and id.endswith( "]" ):
+          filter_ids = list( filter( lambda source_id: re.search( id[1:-1], source_id ), source.keys() ) )
+          if len( filter_ids ) > 0:
+            self.log( f"Applying patch filter '{id[1:-1]}' to [{len(filter_ids)}] {gentype}s" )
+            for filter_id in filter_ids:
+              self.log( f"Applying patch filter to {gentype} '{filter_id}'", level=15 )
+              source[filter_id].log_push( 2 )
+              source[filter_id].push_logscope( "patch" )
+              source[filter_id].load_options( options.copy(), origin )
+              source[filter_id].pop_logscope()
+              source[filter_id].log_pop( 2 )
+          else:
+            self.log( f"No {gentype} matches patch filter '{id[1:-1]}', cannot apply patch", level=30 )
+        else:
+          self.log( f"{gentype} '{id}' does not exist, cannot patch", level=30 )
 
-        if len( patch ) > 0:
-          self.log( f"Unused keys in patch : {list(patch.keys())}", level=30 )
-        self.log_pop()
+    if len( patch ) > 0:
+      self.log( f"Unused keys in patch : {list(patch.keys())}", level=30 )
 
+    self.log_pop()
     self.pop_logscope()
 
   def find_host( self, as_host : str ):
@@ -872,7 +891,8 @@ class Orchestrator( opts.OptionLoader ):
     be created via JSON config file.
 
     .. hint::
-        See :py:meth:`process_patches()` for advanced usage of patching objects, including using patch filters.
+        See :py:meth:`process_patches()` or :py:meth:`process_patch_dict` for advanced
+        usage of patching objects, including using patch filters.
 
     .. note::
         ``"type"`` is not a valid field in any of the ``"patches"`` sub-dicts as the *options*


### PR DESCRIPTION
This breaks out the primary logic previously found in `process_patches` to allow a single patch `dict` to be processed. The original function still sorts and processes in priority order, but with the single patch function available now it can be called to immediately patch the workflow with the patch syntax.

The command line option `--patch` runs _immediately after_ the workflow is fully loaded but before any other operations are performed. This effectively makes it the lowest priority patch. As patch priority is inverse to final precedent (first patches may be overwritten by later priority patches) the command line patch always has precedence being applied last.

Usage may look like:
```
sane_runner -p demo/ --patch '{ "actions" : { "action_000" : { "config" : { "foo" : 5 } } } }'
```