### PR TITLE
Fix queue assignment from default None

### DIFF
--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -609,7 +609,7 @@ class PBSHost( HPCHost ):
 
   def requisition_to_submit_args( self, requisition ):
     host_arguments = []
-    queues = [[None]]   # Default to [None] if no requisition exists
+    queues = []
     for nodeset, req in requisition.items():
       submit_args = []
       if len( host_arguments ) == 0:
@@ -630,8 +630,11 @@ class PBSHost( HPCHost ):
 
       queues.append( self._resources[nodeset]["queues"] )
 
-    # Find the common queue
-    queue = list( reduce( set.intersection, map( set, queues ) ) )[0]
+    if queues:
+      # Find the common queue
+      queue = list( reduce( set.intersection, map( set, queues ) ) )[0]
+    else:
+      queue = None
 
     return host_arguments, queue
 


### PR DESCRIPTION
Setting the default to `[[None]]` causes a null intersection when an actual requisition exists. Instead default to an empty list, and after conversion if the `queues` list is empty then the return `queue` is `None`, otherwise try to do a set reduction.