### PR TITLE
Delay python logging file generation

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -344,7 +344,7 @@ class Action( state.SaveState, res.ResourceRequestor ):
     self.default_log_level = slogger.ACT_INFO
     # Create our own logger instance
     self.logger = slogger.logging.getLogger( __name__ ).getChild( self.id )
-    file_handler = slogger.logging.FileHandler( self.logfile, mode="w" )
+    file_handler = slogger.logging.FileHandler( self.logfile, delay=True, mode="w" )
     file_handler.setFormatter( slogger.log_formatter )
     self.logger.addHandler( file_handler )
     self.logger.setLevel( slogger.STDOUT )


### PR DESCRIPTION
Without the `delay=True` option, the default behavior immediately opens the new file handle before first write for every Action. Effectively, this means that 1) every action always generates a logfile even if not queued to run and 2) all action logs are cleared at workflow start such that the previous logs of completed actions not queued this time are cleared.

This is undesirable behavior and unintuitive for the statefulness that is presented by SANE workflows. Providing the optional value of `delay=True` prevents file overwriting on `FileHandler` creation and instead waits for first write. This solves both 1 & 2 by only creating and updating files for Actions that in some part executed during this workflow run (calls `self.log()`)