### PR TITLE
Allow use of dashes in dereferencing string

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -128,8 +128,8 @@ class Action( state.SaveState, res.ResourceRequestor ):
   * Actions will always execute under separate processes from the :py:class:`sane.Orchestrator`
   """
   CONFIG_TYPE = "Action"
-  REF_RE = re.compile( r"(?P<substr>[$]{{[ ]*(?P<attrs>(?:\w+(?:\[\d+\])?\.)*\w+(?:\[\d+\])?)[ ]*}})" )
-  IDX_RE = re.compile( r"(?P<attr>\w+)(?:\[(?P<idx>\d+)\])?" )
+  REF_RE = re.compile( r"(?P<substr>[$]{{[ ]*(?P<attrs>(?:(?:\w|-)+(?:\[\d+\])?\.)*(?:\w|-)+(?:\[\d+\])?)[ ]*}})" )
+  IDX_RE = re.compile( r"(?P<attr>(?:\w|-)+)(?:\[(?P<idx>\d+)\])?" )
 
   def __init__( self, id ):
     """Create an Action with unique ID"""


### PR DESCRIPTION
The current regex for dereferencing only supports characters as defined by the python re `\w` sequence. This matches alphanumeric characters as well as the underscore (`_`) character. While the `.` is reserved for job name construction when using an HPC host, the common delimeter `-` could be used for instance in Action names.

By modifying the internal regexes used for dereferencing, strings indexing into a dictionary can use `\w|-` as word constructs. This is helpful for when users want to mix both delimeters (`_` and `-`).

For example, previously when referencing a dependency output for an action named `build-linux_x86_gnu_debug` the dereferencing system would silently fail. Now dereference strings like so are valid:
```
"${{ dependencies.build-linux_x86_gnu_debug.outputs.install_dir }}"
```

One should still strive for good consistent naming of action names, outputs, and attributes.