### PR TITLE
Add a helper function for changing the state of __exec_raw__

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -151,7 +151,10 @@ class Action( state.SaveState, res.ResourceRequestor ):
     self._dependencies     = {}
     self._resources        = {}
 
+    # Whether the output of subprocesses should print raw output or wrap it with
+    # logging as if coming from this action's logging
     self.__exec_raw__      = True
+    self.__tmp_exce_raw__  = True
 
     #: The start time of the :py:meth:`Action.launch()` in ISO format
     self.__timestamp__     = None
@@ -207,6 +210,15 @@ class Action( state.SaveState, res.ResourceRequestor ):
         self._run_lock.release()
       else:
         self.log( "Run lock already released", level=30 )
+
+  def push_exec_raw( self, exec_raw : bool ) -> None:
+    """Push a new value of :py:attr:`Action.__exec_raw__`"""
+    self.__tmp_exce_raw__ = self.__exec_raw__
+    self.__exec_raw__ = exec_raw
+
+  def pop_exec_raw( self ) -> None:
+    """Restore previous value of :py:attr:`Action.__exec_raw__`"""
+    self.__exec_raw__ = self.__tmp_exce_raw__
 
   @property
   def id( self ) -> str:

--- a/sane/action_launcher.py
+++ b/sane/action_launcher.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
   environment.setup()
 
   if action.wrap_stdout:
-    action.__exec_raw__ = False
+    action.push_exec_raw( False )
 
   action.pre_run()
   retval = action.run()


### PR DESCRIPTION
Control of whether the output of `Action.execute_subprocess()` is dictated by the internal `Action` attribute `__exec_raw__`.

If users need to execute some subprocess within their custom Action with wrapped logging output, they need to ensure this value is set correctly. Likewise, to ensure consistent logging, users would need to reinstate the previous value after the subprocess finishes.

Rather than require temp variable and read/write of a private variable the control can now be facilitated by a push/pop set of helper functions.

`pop_exec_raw()` should only be called after a corresponding `push_exec_raw()` call. Multiple nested calls are not supported at this time (e.g. multiple push before equivalent pop) as it is meant to only wrap around `execute_subprocess()` calls.