### PR TITLE
Apply consistent log scope

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -738,7 +738,9 @@ class Action( state.SaveState, res.ResourceRequestor ):
       self.log( f"Action logfile captured at {self.logfile}", level=slogger.MAIN_LOG )
 
       self._acquire()
+      self.push_logscope( "pre_launch" )
       ok = self.pre_launch()
+      self.pop_logscope()
       self._release()
       if ok is not None and not ok:
         raise AssertionError( "pre_launch() returned False" )
@@ -800,7 +802,9 @@ class Action( state.SaveState, res.ResourceRequestor ):
           self._status = ActionStatus.SUBMITTED
 
       self._acquire()
+      self.push_logscope( "post_launch" )
       ok = self.post_launch( retval, content )
+      self.pop_logscope()
       self._release()
       if ok is not None and not ok:
         raise AssertionError( "post_launch() returned False" )
@@ -1014,7 +1018,6 @@ class Action( state.SaveState, res.ResourceRequestor ):
              The default returns the return value of :py:meth:`execute_subprocess`
              from running ``config["command"]``
     """
-    self.push_logscope( "run" )
     # Users may overwrite run() in a derived class, but a default will be provided for config-file based testing (TBD)
     # The default will simply launch an underlying command using a subprocess
     self.dereference( self.config )
@@ -1032,7 +1035,6 @@ class Action( state.SaveState, res.ResourceRequestor ):
       arguments = self.config["arguments"]
 
     retval, content = self.execute_subprocess( command, arguments, verbose=True, capture=False )
-    self.pop_logscope()
     return retval
 
   def __str__( self ):

--- a/sane/action_launcher.py
+++ b/sane/action_launcher.py
@@ -42,14 +42,22 @@ if __name__ == "__main__":
   if action.wrap_stdout:
     action.push_exec_raw( False )
 
+  action.push_logscope( "pre_run" )
   action.pre_run()
+  action.pop_logscope()
+
+  action.push_logscope( "run" )
   retval = action.run()
+  action.pop_logscope()
+
+  action.push_logscope( "post_run" )
   action.post_run( retval )
+  action.pop_logscope()
 
   if retval is None:
     retval = -1
     action.log( f"No return value provided by Action {action.id}", level=40 )
 
   action.log(  "*" * 15 + "{:^15}".format( "Finished action_launcher.py" ) + "*" * 15 )
-
+  action.pop_logscope()
   exit( retval )

--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -118,6 +118,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
         self.log( msg, level=40 )
         raise Exception( msg )
       self._job_ids[action.id] = self.extract_job_id( content )
+      self.log( f"Found job id '{self._job_ids[action.id]}' for '{action.id}'" )
     super().post_launch( action, retval, content )
 
   def post_run_actions( self, actions ):
@@ -178,7 +179,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
             dep_jobs[action.dependencies[id]["dep_type"]] = []
           # Construct dependency type -> job id
           if dep_action.id not in self._job_ids:
-            raise KeyError( f"Missing job id for '{dep_action.id}'" )
+            raise KeyError( f"Gathering dependencies for '{action.id}' - missing job id for '{dep_action.id}'" )
           else:
             dep_jobs[action.dependencies[id]["dep_type"]].append( self._job_ids[dep_action.id] )
         # else:

--- a/sane/orchestrator.py
+++ b/sane/orchestrator.py
@@ -580,7 +580,9 @@ class Orchestrator( opts.OptionLoader ):
       self.log( f"Launching Host '{self.current_host}' watchdog function" )
       host_wd_results = executor.submit( host_watchdog, { node : self.actions[node] for node in action_set } )
 
+    host.push_logscope( "pre_run_actions" )
     host.pre_run_actions( { node : self.actions[node] for node in action_set } )
+    host.pop_logscope()
 
     self.log( "Running actions..." )
     start = datetime.datetime.now()
@@ -629,7 +631,9 @@ class Orchestrator( opts.OptionLoader ):
 
                 self.log( f"Running '{node}' on '{self.current_host}'" )
                 with self.__run_lock__:
+                  host.push_logscope( "pre_launch" )
                   host.pre_launch( self.actions[node] )
+                  host.pop_logscope()
                 self.log_flush()
                 results[node] = executor.submit(
                                                 self.actions[node].launch,
@@ -702,7 +706,10 @@ class Orchestrator( opts.OptionLoader ):
         if node in results and node not in processed_nodes:
           try:
             retval, content = results[node].result(10)
+            host.push_logscope( "post_launch" )
             host.post_launch( self.actions[node], retval, content )
+            host.pop_logscope()
+
             # Regardless, return resources
             host.release_resources( self.actions[node].resources( self.current_host ), requestor=self.actions[node] )
             del results[node]
@@ -720,7 +727,9 @@ class Orchestrator( opts.OptionLoader ):
     host.kill_watchdog = True
     executor.shutdown( wait=True )
 
+    host.push_logscope( "post_run_actions" )
     host.post_run_actions( { node : self.actions[node] for node in action_set } )
+    host.pop_logscope()
 
     self.log( "Finished running queued actions" )
     # Report final statuses


### PR DESCRIPTION
Setting the log scope at the caller level of the user defined functions
ensures that the user does not need to set any scope of their own,
regardless of any inheritance.

Users are still free to set their own scopes within functions, but these
functions will always start with a base scope corresponding to the
function name.