### PR TITLE
Simplify dereference string processing

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -128,8 +128,8 @@ class Action( state.SaveState, res.ResourceRequestor ):
   * Actions will always execute under separate processes from the :py:class:`sane.Orchestrator`
   """
   CONFIG_TYPE = "Action"
-  REF_RE = re.compile( r"(?P<substr>[$]{{[ ]*(?P<attrs>(?:(?:\w|-)+(?:\[\d+\])?\.)*(?:\w|-)+(?:\[\d+\])?)[ ]*}})" )
-  IDX_RE = re.compile( r"(?P<attr>(?:\w|-)+)(?:\[(?P<idx>\d+)\])?" )
+  REF_RE = re.compile( r"(?P<substr>[$]{{[ ]*(?P<attrs>(?:(?:\w|-)+(?:\[[ ]*\d+[ ]*\])?\.?)+)[ ]*}})" )
+  IDX_RE = re.compile( r"(?P<attr>(?:\w|-)+)(?:\[[ ]*(?P<idx>\d+)[ ]*\])?" )
 
   def __init__( self, id ):
     """Create an Action with unique ID"""
@@ -835,11 +835,11 @@ class Action( state.SaveState, res.ResourceRequestor ):
     """Dereference an input string using GitHub Actions style syntax scoped to the current object
     
     Continuously dereferences strings within the current object until no more 
-    substitutions can be made. All attributes and properties can be referenced,
-    but dereferencing will work best with attributes that are ``dict``, ``list``,
-    ``str``, or ``int`` values.
+    substitutions can be made. This means that dereference strings can be nested.
+    All attributes and properties can be referenced, but dereferencing will work
+    best with attributes that are ``dict``, ``list``, ``str``, or ``int`` values.
     
-    | Nested referencing can be achieved with ``.`` operator (key as next field)
+    | Dict referencing can be achieved with ``.`` operator (key as next field)
     | Index referencing can be achieved with ``[]`` operator (positive integer)
 
     Valid syntax examples:
@@ -872,6 +872,11 @@ class Action( state.SaveState, res.ResourceRequestor ):
         # A complex dereference
         "${{ config.moo.loo[0].hoo[1] }}" => "7"
 
+        # A nested dereference
+        "${{ config.moo.loo[0].hoo[ ${{ config.moo.loo[ ${{ config.foo }} ] }} ] }} => "6"
+        #                                               ^^^^^^^^^^^^^^^^^ => "1"
+        #                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ => "0"
+
     .. attention:: During the substitution, if indexing to the next attribute yields ``None`` an
                    ``Exception`` will be thrown. Thus, at the time of dereferencing, the string
                    input **MUST** be valid.
@@ -880,28 +885,23 @@ class Action( state.SaveState, res.ResourceRequestor ):
     :param noexcept: disable exceptions and instead allow failed dereference
     :return: string fully dereferenced
     """
-    curr_matches = list( Action.REF_RE.finditer( input_str ) )
-    prev_matches = None
     output_str = input_str
-
-    def matches_equal( lhs, rhs ):
-      if lhs is None and rhs is not None or rhs is None and lhs is not None:
-        return False
-      if len( lhs ) != len( rhs ):
-        return False
-      for i in range( len( lhs ) ):
-        if lhs[i].span() != rhs[i].span():
-          return False
-        if lhs[i].groupdict() != rhs[i].groupdict():
-          return False
-      return True
+    history    = []
 
     # Fully dereference as much as possible
-    while not matches_equal( prev_matches, curr_matches ):
-      prev_matches = curr_matches
-      for match in curr_matches:
+    while len(history) == 0 or output_str not in history:
+      history.append( output_str )
+      matches = list( Action.REF_RE.finditer( output_str ) )
+
+      for match in matches:
         substr = match.group( "substr" )
         attrs  = match.group( "attrs" )
+
+        # Correct for malformed attributes the regex can catch. This could be
+        # avoided with a lengthier regex but to keep it simple we "fix it in post"
+        if attrs[-1] == ".":
+          self.log( f"Attribute reference '{output_str}' contains dangling '.' : '{attrs}'", level=30 )
+          attrs = attrs[:-1]
 
         curr = self
         for attr in attrs.split( "." ):
@@ -933,17 +933,23 @@ class Action( state.SaveState, res.ResourceRequestor ):
               msg = f"Dereferencing yielded None for '{attr_groups['attr']}' in '{substr}'"
               self.log( msg, level=40 )
               raise Exception( msg )
-          
 
           if attr_groups["idx"] is not None:
             curr = curr[ int(attr_groups["idx"]) ]
         output_str = output_str.replace( substr, str( curr ) )
 
-      curr_matches = list( Action.REF_RE.finditer( output_str ) )
+    if output_str != history[-1]:
+      self.log( f"Detected cyclical dereference at [{history.index(output_str)}].", level=30 )
+      self.log(  "  History:", level=30 )
+      for i, s in enumerate( history ):
+        self.log( f"             [{i}] '{s}'", level=30 )
+      self.log( f"  output =>  [{len(history)}] '{output_str}'", level=30 )
 
-    if output_str != input_str and log:
-      self.log( f"Dereferenced '{input_str}'" )
-      self.log( f"     into => '{output_str}'" )
+    elif output_str != input_str and log:
+      self.log( f"Dereferenced [0] '{input_str}'" )
+      for i, s in enumerate( history[1:-1], 1 ):
+        self.log( f"             [{i}] '{s}'" )
+      self.log( f"     into => [{len(history) - 1}] '{output_str}'" )
     return output_str
 
   def dereference( self, obj, log=True, noexcept=False ):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -128,7 +128,14 @@ class ActionTests( unittest.TestCase ):
     options = {
                 "environment" : "foobar",
                 "local"       : True,
-                "config"      : { "one" : 1, "two" : [2], "three" : { "foo" : 3 } },
+                "config"      :
+                { 
+                  "one" : 1,
+                  "two" : [2],
+                  "three" : { "foo" : 3 },
+                  "foobar" : "foo",
+                  "arr" : [ 3, 2, 1, 0 ]
+                },
                 "dependencies" :
                 {
                   "dep_action0" : "afterok",
@@ -180,9 +187,11 @@ class ActionTests( unittest.TestCase ):
                 {
                   "foo" : "${{ local }}",
                   "foobar" : "${noop}",
+                  "noop" : "${{ }}",
                   "moo" : [ "${{ working_directory}}", "${{ config.one }}", "${{ resources.gpus}}" ]
                 },
-                "boo" : "${{ config.two[0] }}"
+                "boo" : "${{ config.two[0] }}",
+                "moo" : "${{ config.two[ ${{ config.arr[ ${{ config.three.${{ config.foobar }} }} ] }} ] }}"
               }
     exp_dict = {
                 "foo" : "test",
@@ -191,9 +200,11 @@ class ActionTests( unittest.TestCase ):
                 {
                   "foo" : "True",
                   "foobar" : "${noop}",
+                  "noop" : "${{ }}",
                   "moo" : [ "./", "1", "999" ]
                 },
-                "boo" : "2"
+                "boo" : "2",
+                "moo" : "2"
               }
     out_dict = self.action.dereference( ref_dict )
     self.assertEqual( exp_dict, out_dict )
@@ -202,6 +213,68 @@ class ActionTests( unittest.TestCase ):
     self.action.config["foo"] = "${{ config.bar }}"
     self.action.config["bar"] = "1"
     ref_str = "${{config.foo}}"
+    exp_str = "1"
+    out_str = self.action.dereference_str( ref_str )
+    self.assertEqual( exp_str, out_str )
+
+  def test_action_dereference_detect_cycle( self ):
+    """Test the action's ability to detect cycles in attribute dereferencing"""
+    # Start with a sufficiently complex config
+    self.test_action_from_options()
+
+    # Modify action to self reference
+    self.action.config["single_cycle"] = {
+                                          "a" : "${{ config.single_cycle.b }}",
+                                          "b" : "${{ config.single_cycle.a }}"
+                                          }
+
+    ref_str = "${{ config.single_cycle.a }}"
+    exp_str = ref_str
+    out_str = self.action.dereference_str( ref_str )
+    self.assertEqual( exp_str, out_str )
+
+    self.action.config["quad_cycle"] = {
+                                          "a" : "${{ config.quad_cycle.b }}",
+                                          "b" : "${{ config.quad_cycle.c }}",
+                                          "c" : "${{ config.quad_cycle.d }}",
+                                          "d" : "${{ config.quad_cycle.a }}"
+                                          }
+
+    ref_str = "${{ config.quad_cycle.a }}"
+    exp_str = ref_str
+    out_str = self.action.dereference_str( ref_str )
+    self.assertEqual( exp_str, out_str )
+
+    self.action.config["enter_cycle"] = {
+                                          "a" : "${{ config.enter_cycle.b }}",
+                                          "b" : "${{ config.enter_cycle.c }}",
+                                          "c" : "${{ config.enter_cycle.d }}",
+                                          "d" : "${{ config.quad_cycle.b }}"
+                                        }
+    # Enter cycle at b, so expect b out
+    ref_str = "${{ config.enter_cycle.a }}"
+    exp_str = self.action.config["enter_cycle"]["d"]
+    out_str = self.action.dereference_str( ref_str )
+    self.assertEqual( exp_str, out_str )
+
+    # Cycle starts but does one loop to regularize the string so first err will
+    # be at next node
+    ref_str = "${{   config.single_cycle.a   }}"
+    exp_str = self.action.config["single_cycle"]["a"] #goes to next node
+    out_str = self.action.dereference_str( ref_str )
+    self.assertEqual( exp_str, out_str )
+
+  def test_action_dereference_warn_simplified_re( self ):
+    """Test the action's ability to detect malformed reference due to simplified regex"""
+    # Start with a sufficiently complex config
+    self.test_action_from_options()
+
+    # The simplification of the regex to be a repeating pattern with an optional
+    # '.' (key subscript) at the end allows a ref string to end with a '.'
+    self.action.config["foo"] = 1
+
+    # Detect if this is caught
+    ref_str = "${{config.foo.}}"
     exp_str = "1"
     out_str = self.action.dereference_str( ref_str )
     self.assertEqual( exp_str, out_str )


### PR DESCRIPTION
The dereference regex (both full string detection and bracket indexing) originally has two near identical copies to account for any number of repeating sub-references and a final fully formed attribute. If the regex has to be modified for new syntax it must be updated in both locations.

To fix this the regex now expects one or more fully formed attribute expressions that are delimited by '.' character. To avoid duplication of the regex again using lookbehind constructs the expression *does* allow ending a reference string with '.' which is technically malformed.

The logic for processing reference strings consisted of comparing the set of matches and their spans to see if they are roughly equivalent. This was both inefficient, overly complicated, and lacked checking for cycles greater than one step (A->A->A).

An improvement on this is to instead keep a history of each full set of substitutions made in a list, and after the first pass check if the new processed string is within the history. This method both greatly simplifies the check condition if a string is done processing (i.e. it did not change on the next pass therefore no more substitution can be made) and if a complex cycle was encountered (e.g. appears in the history that is not the latest change).

A side benefit to this is our logging info can now include the full breakdown of substitutions per iteration by repeating that history back until the final output, which may be useful for debugging. This info is not controllable at the moment, but may be considered for toggling if it begins to clutter logs.

A reference string with malformed ending ('.') is allowed and produces a warning message, with corrections to the string made in situ during processing.

Tests are included to ensure that this simplification addresses previous issues and is an overall improvement.
