### PR TITLE
Handle deferred Action dependency outputs

### DIFF
--- a/sane/action.py
+++ b/sane/action.py
@@ -191,17 +191,24 @@ class Action( state.SaveState, res.ResourceRequestor ):
     filename = f"{self.save_location}/{self.id}_outputs.json"
     with open( filename, "w" ) as f:
       self.log( f"Saving outputs to : {filename}" )
-      json.dump( self.dereference( self.outputs, noexcept=False ), f, indent=2 )
+      json.dump( self.dereference( self.outputs, noexcept=False, log=False ), f, indent=2 )
 
-  def load_outputs( self ) -> None:
+  def load_outputs( self, id=None, merge=None ) -> None:
     """Read from JSON file in :py:attr:`Action.save_location` and merge with :py:attr:`Action.outputs`"""
-    filename = f"{self.save_location}/{self.id}_outputs.json"
+    if id is None and merge is None:
+      id = self.id
+      merge = self.outputs
+
+    filename = f"{self.save_location}/{id}_outputs.json"
     if os.path.isfile( filename ):
       with open( filename, "r" ) as f:
         loaded = json.load( f )
-        self.outputs = recursive_update( self.outputs, loaded )
-    elif not self.dry_run:
-      self.log( "Action outputs could not be loaded", level=30 )
+        merge = recursive_update( merge, loaded )
+
+  def reload_dependencies_outputs( self ):
+    """Reload dependency output info in case it has changed"""
+    for dep, info in self.dependencies.items():
+      self.load_outputs( dep, info["outputs"] )
 
   def __orch_wake__( self ) -> None:
     """Wake up the :py:class:`Orchestrator` from another thread.

--- a/sane/action_launcher.py
+++ b/sane/action_launcher.py
@@ -42,6 +42,8 @@ if __name__ == "__main__":
   if action.wrap_stdout:
     action.push_exec_raw( False )
 
+  action.reload_dependencies_outputs()
+
   action.push_logscope( "pre_run" )
   action.pre_run()
   action.pop_logscope()


### PR DESCRIPTION
Ensure that dependency outputs are current at Action start

To account for different execution context between the orchestrator task and the actual Action run, Actions must save+load their outputs.

This is fine for a local run host where the tasks are directly executed by the main orchestrator process and thus executed in DAG-dependency order. However in HPC environments tasks are submitted into a queue in DAG order with dependency info set at that time. Execution and thus evaluation of outputs will not occur until the real host runs the job.

This delay would cause dependency outputs to run with the old values set at submission time instead of the values after dependencies have finished executing. To remedy this, building off of #52, Actions now reload the dependency outputs inside the `action_launcher.py`

Note that dependency outputs will still be incorrect within the main orchestrator process context, but at this stage this information should not be needed as is never stored beyond the pickle file. Should users need the dependency output information per action in this situation (e.g. post_run_actions() for the Host) users can call the internal API function `Action.reload_dependency_outputs()` manually.