### PR TITLE
Suppress stdout from env loading script to avoid python exec pollution

### DIFF
--- a/sane/env_from_script.sh
+++ b/sane/env_from_script.sh
@@ -45,7 +45,9 @@ import json
 json.dump( env, open( "$save_env", "w" ), indent=2 )
 EOF
 
-. $script
+# Ensure that any rogue stdout from script does not pollute ingestion of
+# generated python commands. Perhaps later we can wrap and output this as stdout/log
+. $script &> /dev/null
 
 output=$( env )
 python3 << EOF


### PR DESCRIPTION
Without this suppression environment loading scripts that give verbose information (e.g. intel setvars.sh) will have these lines executed by the Python `exec()` function. Best case, it is total nonsense and throws an error, worst case it executes some catastrophic code.

Note that the loader still executes perceived differences in the env, so users should be cautious about loading scripts and be aware of code injection.