### PR TITLE
Create mock HPC system to test deferred execution

### DIFF
--- a/sane/hpc_host.py
+++ b/sane/hpc_host.py
@@ -17,6 +17,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
     super().__init__( name=name, aliases=aliases )
     # Maybe find a better way to do this
     self._base = HPCHost
+    self._delay_sec = HPCHost.HPC_DELAY_PERIOD_SECONDS
 
     # Defaults
     self.queue   = None
@@ -28,6 +29,8 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
     self._completed = {}
 
     # These must be filled out by derived classes
+
+    # state and status commands should accept 1 format argument as job id
     self._state_cmd = None
     self._status_cmd = None
     self._submit_cmd = None
@@ -93,7 +96,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
 
   def capture_job_complete( self, actions, only_watchdog=True ):
     while not self.kill_watchdog and ( only_watchdog or ( len( self._completed ) != len( self._job_ids ) ) ):
-      time.sleep( HPCHost.HPC_DELAY_PERIOD_SECONDS )
+      time.sleep( self._delay_sec )
       for action_name, job_id in self._job_ids.items():
         if action_name not in self._completed and ( self.dry_run or self.job_complete( job_id ) ):
           self._completed[action_name] = job_id
@@ -143,7 +146,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
 
   def job_complete( self, job_id ):
     proc = subprocess.Popen(
-                            ( self._state_cmd + f" {job_id}" ).split( " " ),
+                            self._state_cmd.format( job_id ).split( " " ),
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE
@@ -155,7 +158,7 @@ class HPCHost( sane.resources.NonLocalProvider, sane.host.Host ):
 
   def job_status( self, job_id ):
     proc = subprocess.Popen(
-                            ( self._status_cmd + f" {job_id}" ).split( " " ),
+                            self._status_cmd.format( job_id ).split( " " ),
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE
@@ -287,7 +290,7 @@ class PBSHost( HPCHost ):
     # Keep job info around after query
     self._job_info = {}
 
-    self._state_cmd = "qstat -f -x"
+    self._state_cmd = "qstat -f -x {0}"
     self._status_cmd = self._state_cmd  # same thing
     self._submit_cmd = "qsub"
     self._resources_delim = ":"

--- a/tests/mock_hpc/complete/.gitignore
+++ b/tests/mock_hpc/complete/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files in this directory
+*
+# Except for this file itself
+!.gitignore

--- a/tests/mock_hpc/queue/.gitignore
+++ b/tests/mock_hpc/queue/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files in this directory
+*
+# Except for this file itself
+!.gitignore

--- a/tests/mock_hpc/run.sh
+++ b/tests/mock_hpc/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/sh
+CURRENT_SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+PERIOD=$1
+
+QUEUE_DIR=$CURRENT_SOURCE_DIR/queue
+COMPLETE_DIR=$CURRENT_SOURCE_DIR/complete
+
+rm -f $CURRENT_SOURCE_DIR/queue/*
+rm -f $CURRENT_SOURCE_DIR/complete/*
+rm -f $CURRENT_SOURCE_DIR/kill
+
+if [ -z "$PERIOD" ]; then
+  PERIOD=5
+fi
+
+while [ ! -f $CURRENT_SOURCE_DIR/kill ]; do
+  queue=$( ls $QUEUE_DIR )
+  for cmd_file in $queue; do
+    # echo "Executing ${QUEUE_DIR}/${cmd_file}"
+    deps=$( head -n 1 $QUEUE_DIR/$cmd_file | tr ':' ' ' | sed  's/[^0-9 ]//g' )
+
+    ok="true"
+    if [ -n "$deps" ]; then
+      for d in $deps; do
+        if [ ! -f $COMPLETE_DIR/$d ]; then
+          ok="false"
+        fi
+      done
+    fi
+
+    if [ "$ok" != "true" ]; then
+      continue
+    fi
+
+    cmd=$( tail -n 1 $QUEUE_DIR/$cmd_file )
+    eval "$cmd" &> /dev/null
+    result=$?
+    rm $QUEUE_DIR/$cmd_file
+    echo $result > $COMPLETE_DIR/$cmd_file
+  done
+  sleep $PERIOD
+done
+
+rm -f $CURRENT_SOURCE_DIR/queue/*
+rm -f $CURRENT_SOURCE_DIR/complete/*
+rm -f $CURRENT_SOURCE_DIR/kill

--- a/tests/mock_hpc/submit.sh
+++ b/tests/mock_hpc/submit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/sh
+CURRENT_SOURCE_DIR=$( CDPATH= cd -- "$(dirname -- "$0")" && pwd )
+QUEUE_DIR=$CURRENT_SOURCE_DIR/queue
+COMPLETE_DIR=$CURRENT_SOURCE_DIR/complete
+
+RAW=$*
+CMD=${RAW#*--}
+ARGS=${RAW%%--*}
+id=$( find $QUEUE_DIR/ $COMPLETE_DIR/ -type f | wc -l )
+
+echo "Launching job $id with args \"$ARGS\""
+echo "  $CMD"
+echo -e "$ARGS\n$CMD" > $QUEUE_DIR/$id

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -44,6 +44,17 @@ class ActionTests( unittest.TestCase ):
     if os.path.isfile( state.pickle_file ):
       os.remove( state.pickle_file )
 
+    if isinstance( state, sane.Action ):
+      f = f"{state.save_location}/{state.id}_outputs.json"
+      if os.path.isfile( f ):
+        os.remove( f )
+      f = state.runlog
+      if f is not None and os.path.isfile( f ):
+        os.remove( f )
+      f = state.logfile
+      if f is not None and os.path.isfile( f ):
+        os.remove( f )
+
   def test_action_standalone( self ):
     """Ensure that an action can be created standalone"""
     pass

--- a/tests/test_hpc_host.py
+++ b/tests/test_hpc_host.py
@@ -14,7 +14,7 @@ class MockHPC( sane.HPCHost ):
     self.account = "foobar"
     self.runner_dir = os.path.dirname( __file__ ) + "/mock_hpc"
     self.runner = None
-    self._state_cmd  = f"cat {self.runner_dir}/complete/{0}"
+    self._state_cmd  = f"cat {self.runner_dir}/complete/{{0}}"
     self._status_cmd = self._state_cmd
     self._submit_cmd = f"{self.runner_dir}/submit.sh"
     self._delay_sec = 0.1

--- a/tests/test_hpc_host.py
+++ b/tests/test_hpc_host.py
@@ -1,7 +1,75 @@
 import unittest
+import subprocess
+import os
+import re
+import sys
 
 import sane
 from sane.helpers import recursive_update
+
+
+class MockHPC( sane.HPCHost ):
+  def __init__( self, name, aliases=[] ):
+    super().__init__(name, aliases)
+    self.account = "foobar"
+    self.runner_dir = os.path.dirname( __file__ ) + "/mock_hpc"
+    self.runner = None
+    self._state_cmd  = f"cat {self.runner_dir}/complete/{0}"
+    self._status_cmd = self._state_cmd
+    self._submit_cmd = f"{self.runner_dir}/submit.sh"
+    self._delay_sec = 0.1
+    self._cmd_delim = "--"
+    self._submit_format["dependency"] = "{0}"
+
+  def pre_run_actions( self, actions ):
+    # Launch mock runner with 1 second delay
+    self.runner = subprocess.Popen( [ self.runner_dir + "/run.sh", "0.1" ] )
+    return super().pre_run_actions( actions )
+
+  def post_run_actions( self, actions ):
+    # Complete post run processing
+    super().post_run_actions(actions)
+
+    # Kill the mock runner
+    with open( self.runner_dir + "/kill", "w" ):
+      pass
+
+    self.runner.wait()
+
+  def check_job_complete( self, job_id, retval, status ):
+    if retval != 0:
+      return False
+
+    return True
+
+  def check_job_status( self, job_id, retval, status ):
+    complete = self.check_job_complete( job_id, retval, status )
+    if not complete:
+      return False
+
+    return int(status) == 0
+
+  def extract_job_id( self, content ):
+    found = re.match( r"^Launching job (\d+)", content )
+    if found is None:
+      self.log( "No job id found in output from job submission", level=40 )
+      raise RuntimeError( "No job id found" )
+    else:
+      return int( found.group( 1 ) )
+
+  def submit_args( self, resource_dict, requestor_name ):
+    return {}, "none"
+
+  # These are generally complex and I don't feel like writing them so just don't
+  # over-subscribe your local system, ok?
+  def nonlocal_acquire_resources( self, resource_dict, requestor ):
+    return True
+
+  def nonlocal_release_resources(self, resource_dict, requestor):
+    return True
+
+  def nonlocal_resources_available(self, resource_dict, requestor, log=True):
+    return True
 
 class HPCHostTests( unittest.TestCase ):
   def setUp( self ):

--- a/tests/test_hpc_host.py
+++ b/tests/test_hpc_host.py
@@ -75,6 +75,31 @@ class HPCHostTests( unittest.TestCase ):
   def setUp( self ):
     self.host = sane.PBSHost( "test" )
 
+    # Redirect logging to buffer
+    # https://stackoverflow.com/a/7483862
+    sane.logger.console_handler.stream = sys.stdout
+
+  def tearDown( self ):
+    self.remove_save_files( self.host )
+
+  def remove_save_files( self, state ):
+    if os.path.isfile( state.save_file ):
+      os.remove( state.save_file )
+
+    if os.path.isfile( state.pickle_file ):
+      os.remove( state.pickle_file )
+
+    if isinstance( state, sane.Action ):
+      f = f"{state.save_location}/{state.id}_outputs.json"
+      if os.path.isfile( f ):
+        os.remove( f )
+      f = state.runlog
+      if f is not None and os.path.isfile( f ):
+        os.remove( f )
+      f = state.logfile
+      if f is not None and os.path.isfile( f ):
+        os.remove( f )
+
   def test_pbs_host_standalone( self ):
     """Ensure that a pbs host can be created standalone"""
     pass
@@ -173,3 +198,45 @@ class HPCHostTests( unittest.TestCase ):
       orch.run_actions( ["my_action"], as_host="test" )
     action.add_resource_requirements( { "test" : { "queue" : "queue_foo", "account" : "account_foo" } } )
     orch.run_actions( ["my_action"], as_host="test" )
+
+    self.remove_save_files( action )
+    os.remove( orch.save_file )
+    os.remove( orch.results_file )
+
+  def test_hpc_host_mock( self ):
+    self.host = MockHPC( "mock_hpc" )
+    orch = sane.Orchestrator()
+    self.host.add_environment( sane.Environment( "generic" ) )
+
+    orch.add_host( self.host )
+
+    actionA = sane.Action( "my_actionA" )
+    actionA.import_paths = [ os.path.dirname( __file__ ) ]
+    actionA.config["command"] = "echo"
+    actionA.config["arguments"] = ["foo bar zoo zar"]
+    actionA.environment = "generic"
+
+    actionB = sane.Action( "my_actionB" )
+    actionB.import_paths = [ os.path.dirname( __file__ ) ]
+    actionB.config["command"] = "echo"
+    actionB.config["arguments"] = ["foo bar zoo zar"]
+    actionB.environment = "generic"
+    actionB.add_dependencies( actionA.id )
+
+    orch.add_action( actionA )
+    orch.add_action( actionB )
+    orch.dry_run = False
+
+    # Test that the action can be submitted
+    orch.run_actions( ["my_actionB"], as_host="mock_hpc" )
+
+    self.assertEqual( actionA.status, sane.ActionStatus.SUCCESS )
+    self.assertEqual( actionA.state, sane.ActionState.FINISHED )
+
+    self.assertEqual( actionB.status, sane.ActionStatus.SUCCESS )
+    self.assertEqual( actionB.state, sane.ActionState.FINISHED )
+
+    self.remove_save_files( actionA )
+    self.remove_save_files( actionB )
+    os.remove( orch.save_file )
+    os.remove( orch.results_file )


### PR DESCRIPTION
Create a very simple "HPC" system focused on behavior of dependency resolution and separate execution context from the `Orchestrator`. The system still has enough capability to properly work with SANE and provide job IDs, state and status values, and execute Actions. It *DOES NOT* handle resource management.

The test is a very simple execution of A->B actions. More tests can be developed later to test correctness of HPC-like behavior beyond dry-runs.